### PR TITLE
feat: 修改MAA中失效的一图流/排班生成器链接

### DIFF
--- a/ui/maa.py
+++ b/ui/maa.py
@@ -89,12 +89,12 @@ class MAA:
 
     def open_yituliu(self):
         self.main.indicate("", 1)
-        weopen("https://ytl.viktorlab.cn/")
+        weopen("https://ark.yituliu.cn/")
         self.main.indicate("打开网页: 一图流", 3)
 
     def open_turns(self):
         self.main.indicate("", 1)
-        weopen("https://ytl.viktorlab.cn/tools/schedule")
+        weopen("https://ark.yituliu.cn/tools/schedule")
         self.main.indicate("打开网页: 排班生成器", 3)
 
     def open_maa(self):


### PR DESCRIPTION
https://ytl.viktorlab.cn 是一图流掉备案时期的临时域名，现在已恢复正式域名https://ark.yituliu.cn/